### PR TITLE
move api call getProviences from VMs to Repository

### DIFF
--- a/prawko.xcworkspace/xcuserdata/jakubklentak.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/prawko.xcworkspace/xcuserdata/jakubklentak.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -64,8 +64,8 @@
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "82"
             endingLineNumber = "82"
-            landmarkName = "ContentView"
-            landmarkType = "14">
+            landmarkName = "previews"
+            landmarkType = "24">
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/prawko/CompositionRoot.swift
+++ b/prawko/CompositionRoot.swift
@@ -19,7 +19,9 @@ enum CompositionRoot {
         watchlistRepository: watchlistRepository
     )
     
-    static var wordsFormViewModel = WordsFormViewModel()
+    static var wordsFormViewModel = WordsFormViewModel(
+        infoCarRepository: infoCarRepository
+    )
     
     static var searchResultViewModel = SearchResultViewModel(
         infoCarRepository: infoCarRepository
@@ -63,7 +65,8 @@ private extension CompositionRoot {
     
     private static var notificationsSettingsViewModel = NotificationsSettingsViewModel(
         watchlistRepository: watchlistRepository,
-        appState: appState
+        appState: appState,
+        infoCarRepository: infoCarRepository
     )
     
     private static var infoCarRepository = InfoCarRepository(

--- a/prawko/Errors/ApiConectionError.swift
+++ b/prawko/Errors/ApiConectionError.swift
@@ -10,4 +10,5 @@ import Foundation
 enum ApiConectionError: Error {
     case parseData(String)
     case login(String)
+    case undefined
 }

--- a/prawko/Mocks/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel/NotificationsSettingsVMMock.swift
+++ b/prawko/Mocks/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel/NotificationsSettingsVMMock.swift
@@ -21,7 +21,7 @@ class NotificationsSettingsVMMock: NotificationsSettingsVMProtocol {
         self._appState = StateObject(wrappedValue: appState)
     }
     
-    func getProviences(completion: @escaping  (ApiConectionError?) -> Void) {
+    func getWords(completion: @escaping  (ApiConectionError?) -> Void) {
         completion(nil);
     }
     

--- a/prawko/Mocks/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel/NotificationsSettingsVMMock.swift
+++ b/prawko/Mocks/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel/NotificationsSettingsVMMock.swift
@@ -21,8 +21,8 @@ class NotificationsSettingsVMMock: NotificationsSettingsVMProtocol {
         self._appState = StateObject(wrappedValue: appState)
     }
     
-    func getProviences(completion: @escaping (Bool) -> Void) {
-        completion(true);
+    func getProviences(completion: @escaping  (ApiConectionError?) -> Void) {
+        completion(nil);
     }
     
     func getWordById(wordId: String) -> Word? {

--- a/prawko/Repositories/InfoCarRepository.swift
+++ b/prawko/Repositories/InfoCarRepository.swift
@@ -14,6 +14,17 @@ class InfoCarRepository {
     init(apiManager: APIManager) {
         self.apiManager = apiManager
     }
+    
+    func getProviences(completion: @escaping (Result<Proviences, ApiConectionError>) -> Void) {
+        AF.request(UrlConst.mainUrl + UrlConst.Dict.provinces)
+            .responseDecodable(of: Proviences.self) { response in
+            guard let result = response.value else {
+                completion(.failure(.undefined))
+                return
+            }
+            completion(.success(result))
+        }
+    }
 
     func getScheduledDays(
         category: DrivingLicenceCategory,

--- a/prawko/ViewModels/Partials/WordsFormViewModel.swift
+++ b/prawko/ViewModels/Partials/WordsFormViewModel.swift
@@ -12,16 +12,22 @@ class WordsFormViewModel: WordsFormVMProtocol {
     @Published var proviencesDTO: Proviences
     @Published var sortedWords: [Word]
     
-    init() {
+    var infoCarRepository: InfoCarRepository
+    
+    init(infoCarRepository: InfoCarRepository) {
         self.proviencesDTO = Proviences(provinces: [Province](), words: [Word]())
         self.sortedWords = [Word]()
+        self.infoCarRepository = infoCarRepository
     }
     
     func getProviences() {
-        AF.request(UrlConst.mainUrl + UrlConst.Dict.provinces)
-            .responseDecodable(of: Proviences.self) { response in
-            guard let result = response.value else { return }
-            self.proviencesDTO = result
+        infoCarRepository.getProviences() { result in
+            switch result {
+            case .failure(_):
+                return
+            case .success(let provinces):
+                self.proviencesDTO = provinces
+            }
         }
     }
     

--- a/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsAddResultViewModel.swift
+++ b/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsAddResultViewModel.swift
@@ -54,7 +54,6 @@ where WatchlistRepository: WatchlistRepositoryProtocol {
             switch response.result {
             case .failure(let error):
                 completion(.failure(error))
-                return
             case .success(let result):
                 self.saveResponse(
                     result: result,
@@ -110,7 +109,6 @@ where WatchlistRepository: WatchlistRepositoryProtocol {
                             return
                         }
                         completion(.success(true))
-                        return
                     }
                 }
             }
@@ -131,13 +129,11 @@ where WatchlistRepository: WatchlistRepositoryProtocol {
                             return
                         }
                         completion(.success(true))
-                        return
                     }
                 }
             }
         case .none:
             completion(.success(true))
-            return
         }
     }
 }

--- a/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel.swift
+++ b/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel.swift
@@ -13,25 +13,27 @@ class NotificationsSettingsViewModel: NotificationsSettingsVMProtocol {
     @StateObject var appState: AppState
 
     var watchlistRepository: WatchlistRepository
+    var infoCarRepository: InfoCarRepository
     
     @Published var words: [Word]
     
-    init(watchlistRepository: WatchlistRepository, appState: AppState) {
+    init(watchlistRepository: WatchlistRepository, appState: AppState, infoCarRepository: InfoCarRepository) {
         self.watchlistRepository = watchlistRepository
+        self.infoCarRepository = infoCarRepository
         appState.watchlistElements = watchlistRepository.getList()
         self._appState = StateObject(wrappedValue: appState)
         self.words = [Word]()
     }
     
-    func getProviences(completion: @escaping (Bool) -> Void) {
-        AF.request(UrlConst.mainUrl + UrlConst.Dict.provinces)
-            .responseDecodable(of: Proviences.self) { response in
-            guard let result = response.value else {
-                completion(false)
-                return
+    func getProviences(completion: @escaping  (ApiConectionError?) -> Void) {
+        infoCarRepository.getProviences() { result in
+            switch(result) {
+            case .success(let provinces):
+                self.words = provinces.words
+                completion(nil)
+            case .failure(let exception):
+                completion(exception)
             }
-            self.words = result.words
-            completion(true)
         }
     }
     

--- a/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel.swift
+++ b/prawko/ViewModels/Tabs/NotificationsSettings/NotificationsSettingsViewModel.swift
@@ -25,7 +25,7 @@ class NotificationsSettingsViewModel: NotificationsSettingsVMProtocol {
         self.words = [Word]()
     }
     
-    func getProviences(completion: @escaping  (ApiConectionError?) -> Void) {
+    func getWords(completion: @escaping  (ApiConectionError?) -> Void) {
         infoCarRepository.getProviences() { result in
             switch(result) {
             case .success(let provinces):

--- a/prawko/ViewModels/Tabs/NotificationsSettings/Protocols/NotificationsSettingsVMProtocol.swift
+++ b/prawko/ViewModels/Tabs/NotificationsSettings/Protocols/NotificationsSettingsVMProtocol.swift
@@ -12,7 +12,7 @@ protocol NotificationsSettingsVMProtocol: ObservableObject {
     
     var appState: AppState { get }
     
-    func getProviences(completion: @escaping  (ApiConectionError?) -> Void)
+    func getWords(completion: @escaping  (ApiConectionError?) -> Void)
 
     func getWordById(wordId: String) -> Word?
     

--- a/prawko/ViewModels/Tabs/NotificationsSettings/Protocols/NotificationsSettingsVMProtocol.swift
+++ b/prawko/ViewModels/Tabs/NotificationsSettings/Protocols/NotificationsSettingsVMProtocol.swift
@@ -12,8 +12,8 @@ protocol NotificationsSettingsVMProtocol: ObservableObject {
     
     var appState: AppState { get }
     
-    func getProviences(completion: @escaping (Bool) -> Void)
-    
+    func getProviences(completion: @escaping  (ApiConectionError?) -> Void)
+
     func getWordById(wordId: String) -> Word?
     
     func setAllowNotifications()

--- a/prawko/ViewModels/Tabs/Search/SearchResultViewModel.swift
+++ b/prawko/ViewModels/Tabs/Search/SearchResultViewModel.swift
@@ -24,7 +24,6 @@ class SearchResultViewModel: SearchResultVMProtocol {
             switch result {
             case .failure(_):
                 completion(false)
-                return
             case .success(let scheduledDays):
                 self.scheduledDays = scheduledDays
                 completion(true)

--- a/prawko/Views/Tabs/NotificationsSettings/NotificationsSettingsView.swift
+++ b/prawko/Views/Tabs/NotificationsSettings/NotificationsSettingsView.swift
@@ -77,12 +77,11 @@ where NotificationSettingsVM: NotificationsSettingsVMProtocol,
                 notificationsSettingsVM.setAllowNotifications()
                 
                 notificationsSettingsVM.getProviences() { completion in
-                    switch completion {
-                    case true:
-                        loading = false
-                    case false:
+                    if completion != nil {
                         downloadDataAlert = true
+
                     }
+                    loading = false
                 }
                 
                 notificationsSettingsVM.isNotificationsEnabled() { result in

--- a/prawko/Views/Tabs/NotificationsSettings/NotificationsSettingsView.swift
+++ b/prawko/Views/Tabs/NotificationsSettings/NotificationsSettingsView.swift
@@ -76,7 +76,7 @@ where NotificationSettingsVM: NotificationsSettingsVMProtocol,
             .onAppear() {
                 notificationsSettingsVM.setAllowNotifications()
                 
-                notificationsSettingsVM.getProviences() { completion in
+                notificationsSettingsVM.getWords() { completion in
                     if completion != nil {
                         downloadDataAlert = true
 


### PR DESCRIPTION
move api call getProviences from WordsFormViewModel and Notifications SettingsViewModel to Repository